### PR TITLE
Stop using removed method

### DIFF
--- a/lib/rspec_api_documentation/writers/writer.rb
+++ b/lib/rspec_api_documentation/writers/writer.rb
@@ -14,7 +14,7 @@ module RspecApiDocumentation
       end
 
       def self.clear_docs(docs_dir)
-        if File.exists?(docs_dir)
+        if File.exist?(docs_dir)
           FileUtils.rm_rf(docs_dir, :secure => true)
         end
         FileUtils.mkdir_p(docs_dir)


### PR DESCRIPTION
The `exists?` method was removed in one of the latest ruby versions and thus blocks generating api docs