### PR TITLE
Fallback to StringIO to prevent nil.rewind errors

### DIFF
--- a/lib/rspec_api_documentation/client_base.rb
+++ b/lib/rspec_api_documentation/client_base.rb
@@ -44,7 +44,7 @@ module RspecApiDocumentation
     end
 
     def read_request_body
-      input = last_request.env["rack.input"]
+      input = last_request.env["rack.input"] || StringIO.new
       input.rewind
       input.read
     end


### PR DESCRIPTION
After updating rack in service-learning-team repository. I went to error, that failed a lot of acceptance specs. I saw that it was solved by someone and tested his solution locally, and it is not breaking anything.

https://github.com/zipmark/rspec_api_documentation/pull/543